### PR TITLE
Fix Netflix E109 by spoofing UA

### DIFF
--- a/src/default-services.js
+++ b/src/default-services.js
@@ -164,6 +164,10 @@ module.exports = [
     url: 'https://netflix.com/browse',
     color: '#E50914',
     style: {},
+    // Netflix recently dropped support for older Electron based browsers.
+    // Spoof a modern Chrome user-agent to restore playback functionality.
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
     permissions: []
   },
   {


### PR DESCRIPTION
## Summary
- spoof a modern user-agent for the Netflix service

## Testing
- `npm test` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f54e4d64c8330bbcae0beae4a4fa4