### PR TITLE
Fix Netflix E109 by spoofing UA

### DIFF
--- a/src/default-services.js
+++ b/src/default-services.js
@@ -164,6 +164,10 @@ module.exports = [
     url: 'https://netflix.com/browse',
     color: '#E50914',
     style: {},
+    // Netflix recently dropped support for older Electron based browsers.
+    // Spoof a modern Chrome user-agent to restore playback functionality.
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
     permissions: []
   },
   {

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,19 @@ const userDataDir = app.getPath('userData');
 // Floating UA variable
 let defaultUserAgent;
 
+// Override Netflix headers to work around outdated browser checks
+function setupNetflixHeaders(ses) {
+  const ua =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+  ses.webRequest.onBeforeSendHeaders({ urls: ['*://*.netflix.com/*'] }, (details, cb) => {
+    details.requestHeaders['User-Agent'] = ua;
+    details.requestHeaders['sec-ch-ua'] = '"Chromium";v="126", "Not.A/Brand";v="99"';
+    details.requestHeaders['sec-ch-ua-mobile'] = '?0';
+    details.requestHeaders['sec-ch-ua-platform'] = '"Windows"';
+    cb({ requestHeaders: details.requestHeaders });
+  });
+}
+
 // Needed for electron-context-menu
 try {
   require('electron-reloader')(module);
@@ -101,6 +114,7 @@ async function createWindow() {
   require('@electron/remote/main').enable(mainWindow.webContents);
 
   defaultUserAgent = mainWindow.webContents.userAgent;
+  setupNetflixHeaders(mainWindow.webContents.session);
 
   // Connect Adblocker to Window if enabled
   if (store.get('options.adblock')) {
@@ -335,6 +349,7 @@ async function createNewWindow() {
   require('@electron/remote/main').enable(newWindow.webContents);
 
   defaultUserAgent = newWindow.webContents.userAgent;
+  setupNetflixHeaders(newWindow.webContents.session);
 
   // Connect Adblocker to Window if enabled
   if (store.get('options.adblock')) {


### PR DESCRIPTION
## Summary
- spoof a modern user-agent for the Netflix service
- override Netflix request headers to bypass outdated browser checks

## Testing
- `npm test` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f54e4d64c8330bbcae0beae4a4fa4