### PR TITLE
Fix Netflix E109 by spoofing navigator UA

### DIFF
--- a/src/client-preload.js
+++ b/src/client-preload.js
@@ -59,3 +59,41 @@ window.addEventListener('DOMContentLoaded', () => {
   replaceText('os-type', osType);
   replaceText('arch-type', archType);
 });
+
+// Spoof a modern user agent for Netflix to bypass E109 checks
+const netflixUA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+if (location.hostname.endsWith('netflix.com')) {
+  try {
+    Object.defineProperty(navigator, 'userAgent', {
+      get: () => netflixUA
+    });
+
+    if ('userAgentData' in navigator) {
+      const uaData = {
+        brands: [
+          { brand: 'Chromium', version: '126' },
+          { brand: 'Not:A-Brand', version: '99' }
+        ],
+        mobile: false,
+        platform: 'Windows',
+        getHighEntropyValues: async hints => {
+          const high = {};
+          if (hints.includes('architecture')) high.architecture = 'x86';
+          if (hints.includes('bitness')) high.bitness = '64';
+          if (hints.includes('model')) high.model = '';
+          if (hints.includes('platformVersion')) high.platformVersion = '15.0.0';
+          if (hints.includes('fullVersion')) high.fullVersion = '126.0.0.0';
+          return high;
+        }
+      };
+
+      Object.defineProperty(navigator, 'userAgentData', {
+        get: () => uaData
+      });
+    }
+  } catch (e) {
+    console.error('Failed to spoof Netflix user agent', e);
+  }
+}

--- a/src/default-services.js
+++ b/src/default-services.js
@@ -164,6 +164,10 @@ module.exports = [
     url: 'https://netflix.com/browse',
     color: '#E50914',
     style: {},
+    // Netflix recently dropped support for older Electron based browsers.
+    // Spoof a modern Chrome user-agent to restore playback functionality.
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
     permissions: []
   },
   {

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,19 @@ const userDataDir = app.getPath('userData');
 // Floating UA variable
 let defaultUserAgent;
 
+// Override Netflix headers to work around outdated browser checks
+function setupNetflixHeaders(ses) {
+  const ua =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+  ses.webRequest.onBeforeSendHeaders({ urls: ['*://*.netflix.com/*'] }, (details, cb) => {
+    details.requestHeaders['User-Agent'] = ua;
+    details.requestHeaders['sec-ch-ua'] = '"Chromium";v="126", "Not.A/Brand";v="99"';
+    details.requestHeaders['sec-ch-ua-mobile'] = '?0';
+    details.requestHeaders['sec-ch-ua-platform'] = '"Windows"';
+    cb({ requestHeaders: details.requestHeaders });
+  });
+}
+
 // Needed for electron-context-menu
 try {
   require('electron-reloader')(module);
@@ -101,6 +114,7 @@ async function createWindow() {
   require('@electron/remote/main').enable(mainWindow.webContents);
 
   defaultUserAgent = mainWindow.webContents.userAgent;
+  setupNetflixHeaders(mainWindow.webContents.session);
 
   // Connect Adblocker to Window if enabled
   if (store.get('options.adblock')) {
@@ -335,6 +349,7 @@ async function createNewWindow() {
   require('@electron/remote/main').enable(newWindow.webContents);
 
   defaultUserAgent = newWindow.webContents.userAgent;
+  setupNetflixHeaders(newWindow.webContents.session);
 
   // Connect Adblocker to Window if enabled
   if (store.get('options.adblock')) {


### PR DESCRIPTION
## Summary
- spoof `navigator.userAgent` and `navigator.userAgentData` for Netflix requests

## Testing
- `npm test` *(fails: ESLint config missing, stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f54e4d64c8330bbcae0beae4a4fa4